### PR TITLE
Fix error rendering multiple Google Maps on the same page

### DIFF
--- a/assets/js/simply-rets-client.js
+++ b/assets/js/simply-rets-client.js
@@ -775,7 +775,7 @@ $_(document).ready(function() {
 
     if(document.getElementById('sr-map-search')) {
 
-        if(typeof google === 'object' && typeof googlemaps === 'object') {
+        if(typeof google === 'object' && typeof google.maps === 'object') {
             // google.maps exists - start map
             startMap();
 

--- a/simply-rets-maps.php
+++ b/simply-rets-maps.php
@@ -32,8 +32,23 @@ class SrSearchMap {
 
     public static function mapWithDefaults() {
         $map = new Map();
-        $map->setAsync(true);
-        $map->setHtmlContainerId('sr_map_canvas');
+
+        // Generate an ident for the map so you can render mutliple
+        // maps on the same page. This isn't the most stable solution,
+        // but we don't have unique identifiers about the current
+        // short-code (and even if we did, it's very possible someone
+        // might want to show two of the same short-codes on the same
+        // page.
+        $ident = rand();
+        $map->setHtmlContainerId("{$ident}");
+
+        // Don't use async so that you can render multiple maps on the
+        // same page. When `async` is true, each map (each short-code)
+        // fetches it's own Google Maps script, causing conflict
+        // errors if there are multiple on the same page. Async does
+        // not have this problem.
+        $map->setAsync(false);
+
         $map->setStylesheetOptions(array(
             'width' => '100%',
             'height' =>  '550px'


### PR DESCRIPTION
I wanted to PR this fix for you since I was already pushing it to SimplyRETS/simplyretswp :)

This _should_ fix the issue loading multiple maps on the same page. See all the comments on the changes here: https://github.com/SimplyRETS/simplyretswp/pull/98

One question: are you using [sr_listings] _and_ [sr_map_search] on the same page? IIRC, you were just using the former. This change still doesn't allow both of those to be mingled on the same page (I can fix that), but it does allow each of the to be used multiple times on the same page.

In other words, this will work:
```
[sr_listings]
[sr_listings]
```
But this will not:
```
[sr_listings]
[sr_map_search]
```

If your use-case was the second one, let me know I'll investigate a fix for that one!